### PR TITLE
Fgfs 342 1

### DIFF
--- a/include/OpenThreads/ReadWriteMutex
+++ b/include/OpenThreads/ReadWriteMutex
@@ -61,6 +61,11 @@ class ReadWriteMutex
             return _readWriteMutex.lock();
         }
 
+        virtual int writeTryLock()
+        {
+            return _readWriteMutex.trylock();
+        }
+
         virtual int writeUnlock()
         {
             return _readWriteMutex.unlock();

--- a/include/osgDB/Registry
+++ b/include/osgDB/Registry
@@ -15,6 +15,7 @@
 #define OSGDB_REGISTRY 1
 
 #include <OpenThreads/ReentrantMutex>
+#include <OpenThreads/ReadWriteMutex>
 
 #include <osg/ref_ptr>
 #include <osg/ArgumentParser>
@@ -119,6 +120,7 @@ class OSGDB_EXPORT Registry : public osg::Referenced
 
         /** get a reader writer which handles specified extension.*/
         ReaderWriter* getReaderWriterForExtension(const std::string& ext);
+        OpenThreads::ReadWriteMutex *getObjectCacheExpiryMutex(){return &_objectCacheExpiryMutex;}
 
         /** gets a reader/writer that handles the extension mapped to by one of
           * the registered mime-types. */
@@ -603,6 +605,7 @@ class OSGDB_EXPORT Registry : public osg::Referenced
         osg::ref_ptr<WriteFileCallback>     _writeFileCallback;
         osg::ref_ptr<FileLocationCallback>  _fileLocationCallback;
 
+        mutable OpenThreads::ReadWriteMutex _objectCacheExpiryMutex;
         OpenThreads::ReentrantMutex _pluginMutex;
         ReaderWriterList            _rwList;
         ImageProcessorList          _ipList;

--- a/src/osgDB/DatabasePager.cpp
+++ b/src/osgDB/DatabasePager.cpp
@@ -898,6 +898,7 @@ void DatabasePager::DatabaseThread::run()
 
         if (databaseRequest.valid())
         {
+            Registry::instance()->getObjectCacheExpiryMutex()->readLock();
 
             // load the data, note safe to write to the databaseRequest since once
             // it is created this thread is the only one to write to the _loadedModel pointer.
@@ -993,7 +994,7 @@ void DatabasePager::DatabaseThread::run()
                 }
 
             }
-
+            Registry::instance()->getObjectCacheExpiryMutex()->readUnlock();
             // _pager->_dataToCompileList->pruneOldRequestsAndCheckIfEmpty();
         }
         else

--- a/src/osgDB/ObjectCache.cpp
+++ b/src/osgDB/ObjectCache.cpp
@@ -12,6 +12,8 @@
 */
 
 #include <osgDB/ObjectCache>
+#include <osgDB/Options>
+#include <osgDB/Registry>
 
 using namespace osgDB;
 
@@ -93,18 +95,26 @@ void ObjectCache::removeExpiredObjectsInCache(double expiryTime)
 {
     OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_objectCacheMutex);
 
-    // Remove expired entries from object cache
-    ObjectCacheMap::iterator oitr = _objectCache.begin();
-    while(oitr != _objectCache.end())
+    if (!Registry::instance()->getObjectCacheExpiryMutex()->writeTryLock())
     {
-        if (oitr->second.second<=expiryTime)
+        // Remove expired entries from object cache
+        ObjectCacheMap::iterator oitr = _objectCache.begin();
+        while (oitr != _objectCache.end())
         {
-            _objectCache.erase(oitr++);
+            if (oitr->second.second < expiryTime)
+            {
+#if __cplusplus > 199711L
+                oitr = _objectCache.erase(oitr);
+#else
+                _objectCache.erase(oitr++);
+#endif
+            }
+            else
+            {
+                ++oitr;
+            }
         }
-        else
-        {
-            ++oitr;
-        }
+        Registry::instance()->getObjectCacheExpiryMutex()->writeUnlock();
     }
 }
 


### PR DESCRIPTION
Fix ObjectCache expiring newly referenced object from the DatabasePager thread.

This fixes a problem that results in a "Deleting still referenced object" when scenery is loading.
