### PR TITLE
Fgfs osg 34 3

### DIFF
--- a/include/OpenThreads/ReadWriteMutex
+++ b/include/OpenThreads/ReadWriteMutex
@@ -61,6 +61,11 @@ class ReadWriteMutex
             return _readWriteMutex.lock();
         }
 
+        virtual int writeTryLock()
+        {
+            return _readWriteMutex.trylock();
+        }
+
         virtual int writeUnlock()
         {
             return _readWriteMutex.unlock();

--- a/include/osgDB/Registry
+++ b/include/osgDB/Registry
@@ -15,6 +15,7 @@
 #define OSGDB_REGISTRY 1
 
 #include <OpenThreads/ReentrantMutex>
+#include <OpenThreads/ReadWriteMutex>
 
 #include <osg/ref_ptr>
 #include <osg/ArgumentParser>
@@ -119,6 +120,7 @@ class OSGDB_EXPORT Registry : public osg::Referenced
 
         /** get a reader writer which handles specified extension.*/
         ReaderWriter* getReaderWriterForExtension(const std::string& ext);
+        OpenThreads::ReadWriteMutex *getObjectCacheExpiryMutex(){return &_objectCacheExpiryMutex;}
 
         /** gets a reader/writer that handles the extension mapped to by one of
           * the registered mime-types. */
@@ -603,6 +605,7 @@ class OSGDB_EXPORT Registry : public osg::Referenced
         osg::ref_ptr<WriteFileCallback>     _writeFileCallback;
         osg::ref_ptr<FileLocationCallback>  _fileLocationCallback;
 
+        mutable OpenThreads::ReadWriteMutex _objectCacheExpiryMutex;
         OpenThreads::ReentrantMutex _pluginMutex;
         ReaderWriterList            _rwList;
         ImageProcessorList          _ipList;

--- a/src/osgDB/DatabasePager.cpp
+++ b/src/osgDB/DatabasePager.cpp
@@ -898,6 +898,7 @@ void DatabasePager::DatabaseThread::run()
 
         if (databaseRequest.valid())
         {
+            Registry::instance()->getObjectCacheExpiryMutex()->readLock();
 
             // load the data, note safe to write to the databaseRequest since once
             // it is created this thread is the only one to write to the _loadedModel pointer.
@@ -993,7 +994,7 @@ void DatabasePager::DatabaseThread::run()
                 }
 
             }
-
+            Registry::instance()->getObjectCacheExpiryMutex()->readUnlock();
             // _pager->_dataToCompileList->pruneOldRequestsAndCheckIfEmpty();
         }
         else

--- a/src/osgDB/ObjectCache.cpp
+++ b/src/osgDB/ObjectCache.cpp
@@ -12,6 +12,8 @@
 */
 
 #include <osgDB/ObjectCache>
+#include <osgDB/Options>
+#include <osgDB/Registry>
 
 using namespace osgDB;
 
@@ -93,18 +95,26 @@ void ObjectCache::removeExpiredObjectsInCache(double expiryTime)
 {
     OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_objectCacheMutex);
 
-    // Remove expired entries from object cache
-    ObjectCacheMap::iterator oitr = _objectCache.begin();
-    while(oitr != _objectCache.end())
+    if (!Registry::instance()->getObjectCacheExpiryMutex()->writeTryLock())
     {
-        if (oitr->second.second<=expiryTime)
+        // Remove expired entries from object cache
+        ObjectCacheMap::iterator oitr = _objectCache.begin();
+        while (oitr != _objectCache.end())
         {
-            _objectCache.erase(oitr++);
+            if (oitr->second.second < expiryTime)
+            {
+#if __cplusplus > 199711L
+                oitr = _objectCache.erase(oitr);
+#else
+                _objectCache.erase(oitr++);
+#endif
+            }
+            else
+            {
+                ++oitr;
+            }
         }
-        else
-        {
-            ++oitr;
-        }
+        Registry::instance()->getObjectCacheExpiryMutex()->writeUnlock();
     }
 }
 

--- a/src/osgPlugins/ac/ac3d.cpp
+++ b/src/osgPlugins/ac/ac3d.cpp
@@ -45,6 +45,7 @@ namespace ac3d {
 osg::Node*
 readFile(std::istream& stream, const osgDB::ReaderWriter::Options* options);
 
+static std::string ac3dSrcFilename;
 }
 
 class geodeVisitor : public osg::NodeVisitor { // collects geodes from scene sub-graph attached to 'this'
@@ -105,6 +106,7 @@ class ReaderWriterAC : public osgDB::ReaderWriter
                 local_opt = new Options;
             local_opt->getDatabasePathList().push_back(osgDB::getFilePath(fileName));
 
+            ac3d::ac3dSrcFilename = fileName;
             ReadResult result = readNode(fin, local_opt.get());
             if (result.validNode())
                 result.getNode()->setName(fileName);
@@ -1329,6 +1331,8 @@ readObject(std::istream& stream, FileData& fileData, const osg::Matrix& parentTr
                     // in case this is an invalid refs count for this primitive
                     // read further, but do not store that primitive
                     bool acceptPrimitive = primitiveBin->beginPrimitive(nRefs);
+                    if(!acceptPrimitive)
+                        OSG_WARN << ac3d::ac3dSrcFilename <<": -- primitive not accepted object " << group->getName() << std::endl;
                     for (unsigned i = 0; i < nRefs; ++i) {
                         // Read the vertex index
                         unsigned index;

--- a/src/osgPlugins/dds/ReaderWriterDDS.cpp
+++ b/src/osgPlugins/dds/ReaderWriterDDS.cpp
@@ -1417,7 +1417,13 @@ public:
                 }
             }
         }
+        // in the case of a .dds.gz the name of the image will blank
+        // so if the options has a name then use this (set in the DDS reader)
+        // for the image filename
+        if (options && !options->getName().empty()) {
+            if (osgImage->valid()) osgImage->setFileName(options->getName());
 
+        }
         return osgImage;
     }
 

--- a/src/osgPlugins/gz/ReaderWriterGZ.cpp
+++ b/src/osgPlugins/gz/ReaderWriterGZ.cpp
@@ -182,6 +182,8 @@ osgDB::ReaderWriter::ReadResult ReaderWriterGZ::readFile(ObjectType objectType, 
 
     std::stringstream strstream(dest);
 
+    local_opt.get()->setName(fileName);
+
     return readFile(objectType, rw, strstream, local_opt.get());
 }
 


### PR DESCRIPTION
ObjectCache expiry fix, AC3D debug, .dds.gz filename

- Fix ObjectCache expiring newly referenced object from the DatabasePager thread. This fixing a problem that results in a "Deleting still referenced object".
- Added better error to AC3D reader (e.g. when vertices not enough)
- keep filename when using .dds.gz

I think this is the right branch this time.